### PR TITLE
♻️refactor: cors 허용 목록에 새로운 백엔드 도메인 주소 추가

### DIFF
--- a/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
@@ -84,6 +84,7 @@ public class SecurityConfig {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(Arrays.asList(
                 "https://artiee.store",
+                "https://api.artiee.store",
                 "https://artie-blond.vercel.app",
                 "http://localhost:5173",
                 "http://localhost:5174"


### PR DESCRIPTION
# ☝️Issue Number

- #109 

##  📌 개요

- api.artiee.store 도메인 주소 cors 허용

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점