### PR TITLE
💚ci: cors 허용 목록에 새로운 백엔드 도메인 주소 추가

### DIFF
--- a/src/main/java/com/project/team5backend/global/config/CorsConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/CorsConfig.java
@@ -24,6 +24,7 @@ public class CorsConfig implements WebMvcConfigurer {
         allowedOrigins.add("http://localhost:5174");
         allowedOrigins.add("https://artie-blond.vercel.app");
         allowedOrigins.add("https://artiee.store");
+        allowedOrigins.add("https://api.artiee.store");
 
         configuration.setAllowedOrigins(allowedOrigins);
 


### PR DESCRIPTION
# ☝️Issue Number

- #116 

##  📌 개요

- api.artiee.store 도메인주소 cors 허용

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점