### PR TITLE
Feat/#121: 이메일 인증 구현

### DIFF
--- a/src/main/java/com/project/team5backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/project/team5backend/domain/auth/controller/AuthController.java
@@ -6,14 +6,16 @@ import com.project.team5backend.domain.auth.service.command.AuthCommandService;
 import com.project.team5backend.global.apiPayload.CustomResponse;
 import com.project.team5backend.global.security.userdetails.CurrentUser;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@Tag(name = "AUTH", description = "AUTH 관련 API")
 public class AuthController {
 
     private final AuthCommandService authCommandService;

--- a/src/main/java/com/project/team5backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/project/team5backend/domain/user/controller/UserController.java
@@ -35,7 +35,13 @@ public class UserController {
     private final UserQueryService userQueryService;
     private final CustomCookieCsrfTokenRepository csrfTokenRepository;
 
-    @Operation(summary = "회원 가입")
+    @Operation(summary = "회원 가입",
+            description = "회원 가입 이메일 인증 코드 발송 + 이메일 인증 코드 검증을 순서대로 수행하지 않으면 가입 불가<br>" +
+                    "필드 입력이 서버가 기대하는 값과 다른 경우 예외 발생<br>" +
+                    "email -> 빈칸일 수 없음, 이메일 형식 준수<br>" +
+                    "password -> 공백없는 8-16자리의 대/소문자+숫자+특수문자만 허용, 사용불가 특수문자 : < > { } | ; ' \"<br>" +
+                    "passwordConfirmation -> password와 동일 & 일치 여부<br>" +
+                    "name -> 이름은 한글만 가능하게 설정 가능하긴 한데, 아직은 그냥 빈칸일 수 없음")
     @PostMapping()
     public CustomResponse<String> createUser(
             @RequestBody @Valid UserReqDTO.UserCreateReqDTO userCreateReqDTO
@@ -52,7 +58,9 @@ public class UserController {
         return CustomResponse.onSuccess(userQueryService.getUserProfile(currentUser.getId()));
     }
 
-    @Operation(summary = "회원 정보 수정")
+    @Operation(summary = "회원 정보 수정",
+            description = "필드 입력이 서버가 기대하는 값과 다른 경우 예외 발생<br>" +
+                    "name -> 이름은 한글만 가능하게 설정 가능하긴 한데, 아직은 그냥 빈칸일 수 없음")
     @PatchMapping("/me")
     public CustomResponse<String> updateUser(
             @AuthenticationPrincipal CurrentUser currentUser,
@@ -63,7 +71,7 @@ public class UserController {
     }
 
     // TODO : 회원 탈퇴시 회원과 관련된 정보를 놔둘것이냐? 삭제할것이냐? 연쇄적으로 소프트 딜리트할 것이냐?
-    @Operation(summary = "회원 탈퇴")
+    @Operation(summary = "회원 탈퇴", description = "인증 관련 쿠키 모두 삭제 + 블랙리스트")
     @DeleteMapping("/withdrawal")
     public CustomResponse<String> withdrawalUser(
             @AuthenticationPrincipal CurrentUser currentUser,

--- a/src/main/java/com/project/team5backend/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/project/team5backend/domain/user/exception/UserErrorCode.java
@@ -11,6 +11,7 @@ public enum UserErrorCode implements BaseErrorCode {
     // ErrorCode
     EMAIL_DUPLICATED(HttpStatus.CONFLICT, "USER409", "이미 가입된 이메일입니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER404", "유저가 존재하지 않습니다"),
+    SIGN_UP_EMAIL_VALIDATION_DOES_NOT_EXIST(HttpStatus.UNAUTHORIZED, "USER401", "회원 가입 이메일 인증을 시도하지 않았거나 변조되었거나 만료되었습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/team5backend/domain/user/service/command/UserCommandServiceImpl.java
+++ b/src/main/java/com/project/team5backend/domain/user/service/command/UserCommandServiceImpl.java
@@ -8,12 +8,17 @@ import com.project.team5backend.domain.user.exception.UserErrorCode;
 import com.project.team5backend.domain.user.exception.UserException;
 import com.project.team5backend.domain.user.repository.UserRepository;
 import com.project.team5backend.global.security.util.JwtUtil;
+import com.project.team5backend.global.util.RedisUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Objects;
+
+import static com.project.team5backend.global.constant.redis.RedisConstant.KEY_SCOPE_SUFFIX;
+import static com.project.team5backend.global.constant.scope.ScopeConstant.SCOPE_SIGNUP;
 import static com.project.team5backend.global.util.UpdateUtils.updateIfChanged;
 
 @Service
@@ -24,9 +29,17 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final PasswordEncoder passwordEncoder;
     private final AuthCommandService authCommandService;
     private final JwtUtil jwtUtil;
+    private final RedisUtils<String> redisUtils;
 
     @Override
     public void createUser(UserReqDTO.UserCreateReqDTO userCreateReqDTO) {
+        // 이메일 인증이 완료되었는지 확인
+        String email = userCreateReqDTO.email();
+        // 해당 이메일 인증이 회원 가입을 위한 것인지 확인
+        if (!Objects.equals(redisUtils.get(email + KEY_SCOPE_SUFFIX), SCOPE_SIGNUP)) {
+            throw new UserException(UserErrorCode.SIGN_UP_EMAIL_VALIDATION_DOES_NOT_EXIST);
+        }
+
         User user = UserConverter.toUser(userCreateReqDTO);
         try {
             userRepository.save(user);
@@ -34,6 +47,9 @@ public class UserCommandServiceImpl implements UserCommandService {
         } catch (DataIntegrityViolationException e) {
             throw new UserException(UserErrorCode.EMAIL_DUPLICATED);
         }
+
+        // 가입 성공 시 인증 정보 삭제
+        redisUtils.delete(email + KEY_SCOPE_SUFFIX);
     }
 
     @Override

--- a/src/main/java/com/project/team5backend/global/constant/redis/RedisConstant.java
+++ b/src/main/java/com/project/team5backend/global/constant/redis/RedisConstant.java
@@ -17,6 +17,9 @@ public class RedisConstant {
     // JWT
     public static final String KEY_REFRESH_SUFFIX = ":refresh";
 
+    // SCOPE
+    public static final String KEY_SCOPE_SUFFIX = ":scope";
+
     // -------VALUE-------
 
     // PHONE NUMBER VALIDATION
@@ -28,5 +31,6 @@ public class RedisConstant {
     public static final long CODE_EXP_TIME = 300000L;
     public static final long COOLDOWN_EXP_TIME = 10000L;
 
-
+    // SCOPE
+    public static final long SCOPE_EXP_TIME = 900000L;
 }

--- a/src/main/java/com/project/team5backend/global/constant/redis/RedisConstant.java
+++ b/src/main/java/com/project/team5backend/global/constant/redis/RedisConstant.java
@@ -5,12 +5,28 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RedisConstant {
+    // --------KEY--------
+
+    // PHONE NUMBER VALIDATION
+    public static final String KEY_CODE_SUFFIX = ":code";
+    public static final String KEY_COOLDOWN_SUFFIX = ":cooldown";
 
     // BLACK LIST
     public static final String KEY_BLACK_LIST_SUFFIX = ":blacklist";
 
     // JWT
     public static final String KEY_REFRESH_SUFFIX = ":refresh";
+
+    // -------VALUE-------
+
+    // PHONE NUMBER VALIDATION
+    public static final String VALUE_COOLDOWN = "cooldown...";
+
+    // -------TIME--------
+
+    // PHONE NUMBER VALIDATION
+    public static final long CODE_EXP_TIME = 300000L;
+    public static final long COOLDOWN_EXP_TIME = 10000L;
 
 
 }

--- a/src/main/java/com/project/team5backend/global/constant/scope/ScopeConstant.java
+++ b/src/main/java/com/project/team5backend/global/constant/scope/ScopeConstant.java
@@ -1,0 +1,7 @@
+package com.project.team5backend.global.constant.scope;
+
+public class ScopeConstant {
+    public static final String SCOPE_SIGNUP = "sign-up";
+    public static final String SCOPE_TEMP_PASSWORD = "temp-password";
+    public static final String SCOPE_BIZ_NUMBER = "biz-number";
+}

--- a/src/main/java/com/project/team5backend/global/constant/valid/MessageConstant.java
+++ b/src/main/java/com/project/team5backend/global/constant/valid/MessageConstant.java
@@ -13,7 +13,7 @@ public class MessageConstant {
     public static final String USER_BLANK_CODE = "인증 코드 누락";
 
     // PATTERN EXCEPTION
-    public static final String USER_WRONG_PASSWORD = "공백없는 8-12자리의 대/소문자+숫자+특수문자만 허용, 사용불가 특수문자 : <, >, {, }, |, ;, ', \"";
+    public static final String USER_WRONG_PASSWORD = "공백없는 8-16자리의 대/소문자+숫자+특수문자만 허용, 사용불가 특수문자 : <, >, {, }, |, ;, ', \"";
     public static final String USER_WRONG_CORP_NUMBER = "공백없는 숫자 10자리만 허용";
 
     public static final String USER_WRONG_CODE = "공백없는 숫자 6자리만 허용";

--- a/src/main/java/com/project/team5backend/global/mail/MailType.java
+++ b/src/main/java/com/project/team5backend/global/mail/MailType.java
@@ -1,0 +1,13 @@
+package com.project.team5backend.global.mail;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum MailType {
+    VERIFICATION("[Artie] - 이메일 인증 코드", "src/main/java/com/project/team5backend/global/mail/template/code.html"),
+    ;
+    private final String subject;
+    private final String templatePath;
+}

--- a/src/main/java/com/project/team5backend/global/mail/MailType.java
+++ b/src/main/java/com/project/team5backend/global/mail/MailType.java
@@ -6,7 +6,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum MailType {
-    VERIFICATION("[Artie] - 이메일 인증 코드", "src/main/java/com/project/team5backend/global/mail/template/code.html"),
+    SIGNUP_VERIFICATION("[Artie] - 이메일 인증 코드", "src/main/java/com/project/team5backend/global/mail/template/code.html"),
     ;
     private final String subject;
     private final String templatePath;

--- a/src/main/java/com/project/team5backend/global/mail/exception/MailErrorCode.java
+++ b/src/main/java/com/project/team5backend/global/mail/exception/MailErrorCode.java
@@ -1,0 +1,21 @@
+package com.project.team5backend.global.mail.exception;
+
+import com.project.team5backend.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MailErrorCode implements BaseErrorCode {
+    // ErrorCode
+    TEMPLATE_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "TEMPLATE500", "메일 전송 템플릿을 찾을 수 없습니다."),
+    NOT_DEFINED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL500_1", "정의되지 않은 예외, 로그 확인"),
+    MAIL_SEND_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "MAIL500_2", "메일 전송 실패"),
+    INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "MAIL400", "이메일 파싱 실패 또는 이메일 오류"),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/team5backend/global/mail/exception/MailException.java
+++ b/src/main/java/com/project/team5backend/global/mail/exception/MailException.java
@@ -1,0 +1,9 @@
+package com.project.team5backend.global.mail.exception;
+
+import com.project.team5backend.global.apiPayload.exception.CustomException;
+
+public class MailException extends CustomException {
+    public MailException(MailErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/team5backend/global/mail/service/MailService.java
+++ b/src/main/java/com/project/team5backend/global/mail/service/MailService.java
@@ -1,0 +1,55 @@
+package com.project.team5backend.global.mail.service;
+
+import com.project.team5backend.global.mail.exception.MailErrorCode;
+import com.project.team5backend.global.mail.exception.MailException;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.AddressException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    @Value("${spring.mail.username}") String fromEmail;
+
+    public void sendMail(String toMail, String code) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            helper.setFrom(fromEmail);
+            helper.setTo(toMail);
+            helper.setSubject("[Artie] - 이메일 인증 코드");
+
+            String template = Files.readString(Path.of("src/main/java/com/project/team5backend/global/mail/template/code.html"), StandardCharsets.UTF_8);
+            String html = template
+                    .replace("{{CODE}}", code)
+                            .replace("{{TTL_MINUTES}}", "5");
+
+            helper.setText(html, true);
+            javaMailSender.send(mimeMessage);
+
+        } catch (IOException e) {
+            throw new MailException(MailErrorCode.TEMPLATE_NOT_FOUND);
+        } catch (AddressException e) {
+            throw new MailException(MailErrorCode.INVALID_ADDRESS);
+        } catch (MessagingException e) {
+            throw new MailException(MailErrorCode.MAIL_SEND_ERROR);
+        } catch (Exception e) {
+            throw new MailException(MailErrorCode.NOT_DEFINED_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/project/team5backend/global/mail/template/code.html
+++ b/src/main/java/com/project/team5backend/global/mail/template/code.html
@@ -109,7 +109,7 @@
                                     <p class="meta"
                                        style="margin:0;color:#9aa1ad;
                                 font:400 12px/18px -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;">
-                                        본 메일은 발신 전용입니다. 문의: 문의? 그런 것은 존재하지 않아 스스로 해결해 -ㅇㄱㅇ
+                                        본 메일은 발신 전용입니다.<br>문의: 문의? 그런 것은 존재하지 않아 스스로 해결해 -ㅇㄱㅇ
 <!--                                        <a href="mailto:support@artiee.store" style="color:#E86F70;text-decoration:none;">support@artiee.store</a>-->
                                     </p>
                                 </td>

--- a/src/main/java/com/project/team5backend/global/mail/template/code.html
+++ b/src/main/java/com/project/team5backend/global/mail/template/code.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>Artie 인증코드</title>
+    <meta name="color-scheme" content="light dark">
+    <meta name="supported-color-schemes" content="light dark">
+    <style>
+        @media (max-width: 520px){
+            .wrap { padding: 16px !important; }
+            .title { font-size: 22px !important; line-height: 30px !important; }
+            .code  { font-size: 28px !important; letter-spacing: 6px !important; padding: 14px 18px !important; }
+        }
+        @media (prefers-color-scheme: dark){
+            body { background:#0b0c0e !important; }
+            .card { background:#16181c !important; border-color:#2a2e35 !important; }
+            .text, .meta, .title, .brand { color:#e5e7eb !important; }
+            .muted { color:#a1a1aa !important; }
+        }
+    </style>
+</head>
+<body style="margin:0;padding:0;background:#f6f7fb;">
+<div style="display:none;visibility:hidden;opacity:0;height:0;width:0;overflow:hidden;mso-hide:all;">
+    인증코드 {{CODE}} · 유효 {{TTL_MINUTES}}분
+</div>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#f6f7fb;">
+    <tr>
+        <td align="center" style="padding:28px 0;">
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width:620px;">
+                <tr>
+                    <td class="wrap" style="padding:0 20px;">
+                        <!-- 브랜드 -->
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-bottom:14px;">
+                            <tr>
+                                <td align="left">
+                                    <div class="brand"
+                                         style="font:800 30px/1 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
+                                  color:#E86F70;letter-spacing:.5px;">
+                                        Artie
+                                    </div>
+                                    <div class="muted"
+                                         style="margin-top:6px;color:#9ca3af;font:500 12px/18px -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Arial,'Noto Sans KR',sans-serif;">
+                                        전시와 공간을 잇는, 더 쉬워진 시작을 위해.
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+
+                        <!-- 카드 -->
+                        <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+                               class="card"
+                               style="background:#ffffff;border:1px solid #eceff4;border-radius:14px;overflow:hidden;
+                              box-shadow:0 8px 24px rgba(0,0,0,.06);">
+                            <tr>
+                                <td style="padding:0;">
+                                    <div style="background: linear-gradient(180deg,#fff 0%,#fff 65%,#f9fafb 100%);height:56px;"></div>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td style="padding:0 24px 8px 24px;">
+                                    <h1 class="title"
+                                        style="margin:0 0 10px 0;color:#111827;
+                                 font:800 24px/32px -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;">
+                                        이메일 인증코드
+                                    </h1>
+                                    <p class="text"
+                                       style="margin:0 0 18px 0;color:#4b5563;
+                                font:400 15px/22px -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;">
+                                        아래 6자리 코드를 인증 화면에 입력해 주세요.<br>보안을 위해 타인과 공유하지 마세요.
+                                    </p>
+
+                                    <!-- 코드 박스 -->
+                                    <table role="presentation" align="center" cellpadding="0" cellspacing="0" style="margin:4px auto 0 auto;">
+                                        <tr>
+                                            <td class="code"
+                                                style="font:800 32px/1 ui-monospace,SFMono-Regular,Menlo,Consolas,Monaco,monospace;
+                                     letter-spacing:8px;
+                                     color:#ffffff;
+                                     background:#E86F70;
+                                     border:1px solid rgba(232,111,112,.85);
+                                     border-radius:12px;
+                                     padding:16px 22px;
+                                     text-align:center;">
+                                                {{CODE}}
+                                            </td>
+                                        </tr>
+                                    </table>
+
+                                    <p class="meta"
+                                       style="margin:14px 0 0 0;color:#6b7280;
+                                font:400 13px/20px -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;">
+                                        유효 시간: <b>{{TTL_MINUTES}}분</b>
+                                    </p>
+
+                                    <div style="height:18px;"></div>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td style="padding:0 24px;">
+                                    <hr style="border:none;border-top:1px solid #eef0f4;margin:0;">
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <td style="padding:14px 24px 20px 24px;">
+                                    <p class="meta"
+                                       style="margin:0;color:#9aa1ad;
+                                font:400 12px/18px -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;">
+                                        본 메일은 발신 전용입니다. 문의: 문의? 그런 것은 존재하지 않아 스스로 해결해 -ㅇㄱㅇ
+<!--                                        <a href="mailto:support@artiee.store" style="color:#E86F70;text-decoration:none;">support@artiee.store</a>-->
+                                    </p>
+                                </td>
+                            </tr>
+                        </table>
+
+                        <div style="height:16px;"></div>
+                        <div aria-hidden="true"
+                             style="font:800 42px/1 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,'Apple SD Gothic Neo','Noto Sans KR',sans-serif;
+                            letter-spacing:1px;color:rgba(17,24,39,0.06);">
+                            Artie
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/src/main/java/com/project/team5backend/global/validation/controller/ValidationController.java
+++ b/src/main/java/com/project/team5backend/global/validation/controller/ValidationController.java
@@ -1,0 +1,13 @@
+package com.project.team5backend.global.validation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/validations")
+@Tag(name = "Validation", description = "인증 관련 API")
+public class ValidationController {
+}

--- a/src/main/java/com/project/team5backend/global/validation/controller/ValidationController.java
+++ b/src/main/java/com/project/team5backend/global/validation/controller/ValidationController.java
@@ -23,12 +23,30 @@ public class ValidationController {
 
     private final ValidationService validationService;
 
-    @Operation(summary = "이메일 인증 코드 발송", description = "회원 가입시에만 사용 <br> 메시지 전송 구현했으나, 일단 resBody로도 제공")
+    @Operation(summary = "회원 가입 이메일 인증 코드 발송",
+            description = "회원 가입시에만 사용<br> " +
+                    "메시지 전송 구현했으나, 일단 resBody로도 제공 <br>" +
+                    "이메일 인증은 서버 안정성을 위해 10초의 대기시간 존재<br>" +
+                    "이메일 인증 코드는 5분간 유효, 인증 성공시 해당 이메일은 15분간 타인의 회원가입에 사용불가<br>" +
+                    "인증 완료 후 15분까지 회원 가입을 하지 못하면 해당 이메일로 재인증 필요, 가입 제한<br>" +
+                    "이메일 형식을 지키지 않으면 예외")
     @PostMapping("/sign-up")
     public CustomResponse<String> sendSignUpCode(
             @RequestBody @Valid ValidationReqDTO.EmailCodeReqDTO emailCodeReqDTO
     ) {
         String code = validationService.sendCode(MailType.SIGNUP_VERIFICATION, SCOPE_SIGNUP, emailCodeReqDTO);
         return CustomResponse.onSuccess("메일 발송 성공! code: " + code);
+    }
+
+    @Operation(summary = "이메일 인증 코드 검증",
+            description = "각 코드 요청에 따른 인증 정보를 서버에 15분간 저장<br>" +
+                    "15분이 지나면 재인증 필요 -> 코드 인증을 필요로 하는 모든 서비스 이용 불가<br>" +
+                    "인증 코드는 정수 6자리 and 적절한 이메일 형식 -> 아닐시 예외")
+    @PostMapping("/confirmation")
+    public CustomResponse<String> verifyCode(
+            @RequestBody @Valid ValidationReqDTO.EmailCodeValidationReqDTO emailCodeValidationReqDTO
+    ) {
+        validationService.verifyCode(emailCodeValidationReqDTO);
+        return CustomResponse.onSuccess("이메일 인증 성공!");
     }
 }

--- a/src/main/java/com/project/team5backend/global/validation/controller/ValidationController.java
+++ b/src/main/java/com/project/team5backend/global/validation/controller/ValidationController.java
@@ -1,13 +1,34 @@
 package com.project.team5backend.global.validation.controller;
 
+import com.project.team5backend.global.apiPayload.CustomResponse;
+import com.project.team5backend.global.mail.MailType;
+import com.project.team5backend.global.validation.dto.request.ValidationReqDTO;
+import com.project.team5backend.global.validation.service.ValidationService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.project.team5backend.global.constant.scope.ScopeConstant.SCOPE_SIGNUP;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/validations")
 @Tag(name = "Validation", description = "인증 관련 API")
 public class ValidationController {
+
+    private final ValidationService validationService;
+
+    @Operation(summary = "이메일 인증 코드 발송", description = "회원 가입시에만 사용 <br> 메시지 전송 구현했으나, 일단 resBody로도 제공")
+    @PostMapping("/sign-up")
+    public CustomResponse<String> sendSignUpCode(
+            @RequestBody @Valid ValidationReqDTO.EmailCodeReqDTO emailCodeReqDTO
+    ) {
+        String code = validationService.sendCode(MailType.SIGNUP_VERIFICATION, SCOPE_SIGNUP, emailCodeReqDTO);
+        return CustomResponse.onSuccess("메일 발송 성공! code: " + code);
+    }
 }

--- a/src/main/java/com/project/team5backend/global/validation/converter/ValidationConverter.java
+++ b/src/main/java/com/project/team5backend/global/validation/converter/ValidationConverter.java
@@ -1,0 +1,9 @@
+package com.project.team5backend.global.validation.converter;
+
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ValidationConverter {
+}

--- a/src/main/java/com/project/team5backend/global/validation/dto/request/ValidationReqDTO.java
+++ b/src/main/java/com/project/team5backend/global/validation/dto/request/ValidationReqDTO.java
@@ -2,8 +2,10 @@ package com.project.team5backend.global.validation.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
-import static com.project.team5backend.global.constant.valid.MessageConstant.USER_BLANK_EMAIL;
+import static com.project.team5backend.global.constant.valid.MessageConstant.*;
+import static com.project.team5backend.global.constant.valid.PatternConstant.USER_CODE_PATTERN;
 
 public class ValidationReqDTO {
 
@@ -11,6 +13,17 @@ public class ValidationReqDTO {
             @NotBlank(message = USER_BLANK_EMAIL)
             @Email
             String email
+    ) {
+    }
+
+    public record EmailCodeValidationReqDTO(
+            @NotBlank(message = USER_BLANK_EMAIL)
+            @Email
+            String email,
+
+            @NotBlank(message = USER_BLANK_CODE)
+            @Pattern(regexp = USER_CODE_PATTERN, message = USER_WRONG_CODE)
+            String code
     ) {
     }
 }

--- a/src/main/java/com/project/team5backend/global/validation/dto/request/ValidationReqDTO.java
+++ b/src/main/java/com/project/team5backend/global/validation/dto/request/ValidationReqDTO.java
@@ -1,4 +1,16 @@
 package com.project.team5backend.global.validation.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+import static com.project.team5backend.global.constant.valid.MessageConstant.USER_BLANK_EMAIL;
+
 public class ValidationReqDTO {
+
+    public record EmailCodeReqDTO(
+            @NotBlank(message = USER_BLANK_EMAIL)
+            @Email
+            String email
+    ) {
+    }
 }

--- a/src/main/java/com/project/team5backend/global/validation/dto/request/ValidationReqDTO.java
+++ b/src/main/java/com/project/team5backend/global/validation/dto/request/ValidationReqDTO.java
@@ -1,0 +1,4 @@
+package com.project.team5backend.global.validation.dto.request;
+
+public class ValidationReqDTO {
+}

--- a/src/main/java/com/project/team5backend/global/validation/dto/response/ValidationResDTO.java
+++ b/src/main/java/com/project/team5backend/global/validation/dto/response/ValidationResDTO.java
@@ -1,0 +1,4 @@
+package com.project.team5backend.global.validation.dto.response;
+
+public class ValidationResDTO {
+}

--- a/src/main/java/com/project/team5backend/global/validation/exception/ValidationErrorCode.java
+++ b/src/main/java/com/project/team5backend/global/validation/exception/ValidationErrorCode.java
@@ -1,0 +1,17 @@
+package com.project.team5backend.global.validation.exception;
+
+import com.project.team5backend.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ValidationErrorCode implements BaseErrorCode {
+    // ErrorCode
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/project/team5backend/global/validation/exception/ValidationErrorCode.java
+++ b/src/main/java/com/project/team5backend/global/validation/exception/ValidationErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum ValidationErrorCode implements BaseErrorCode {
     // ErrorCode
     ALREADY_USED_EMAIL(HttpStatus.CONFLICT, "VALID409", "이미 사용중인 이메일입니다."),
-    CODE_COOL_DOWN(HttpStatus.BAD_GATEWAY, "MSG502_2", "잠시 후 다시 시도해주세요. 메일은 10초에 한 번만 보낼 수 있습니다."),
+    CODE_COOL_DOWN(HttpStatus.BAD_GATEWAY, "VALID502", "잠시 후 다시 시도해주세요. 메일은 10초에 한 번만 보낼 수 있습니다."),
+    VALIDATION_REQUEST_DOES_NOT_EXIST(HttpStatus.UNPROCESSABLE_ENTITY, "VALID422", "해당 이메일과 관련된 인증이 없거나 인증 코드가 유효하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/team5backend/global/validation/exception/ValidationErrorCode.java
+++ b/src/main/java/com/project/team5backend/global/validation/exception/ValidationErrorCode.java
@@ -9,6 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum ValidationErrorCode implements BaseErrorCode {
     // ErrorCode
+    ALREADY_USED_EMAIL(HttpStatus.CONFLICT, "VALID409", "이미 사용중인 이메일입니다."),
+    CODE_COOL_DOWN(HttpStatus.BAD_GATEWAY, "MSG502_2", "잠시 후 다시 시도해주세요. 메일은 10초에 한 번만 보낼 수 있습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/project/team5backend/global/validation/exception/ValidationException.java
+++ b/src/main/java/com/project/team5backend/global/validation/exception/ValidationException.java
@@ -1,0 +1,9 @@
+package com.project.team5backend.global.validation.exception;
+
+import com.project.team5backend.global.apiPayload.exception.CustomException;
+
+public class ValidationException extends CustomException {
+    public ValidationException(ValidationErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/project/team5backend/global/validation/service/ValidationService.java
+++ b/src/main/java/com/project/team5backend/global/validation/service/ValidationService.java
@@ -1,0 +1,4 @@
+package com.project.team5backend.global.validation.service;
+
+public interface ValidationService {
+}

--- a/src/main/java/com/project/team5backend/global/validation/service/ValidationService.java
+++ b/src/main/java/com/project/team5backend/global/validation/service/ValidationService.java
@@ -1,4 +1,9 @@
 package com.project.team5backend.global.validation.service;
 
+import com.project.team5backend.global.mail.MailType;
+import com.project.team5backend.global.validation.dto.request.ValidationReqDTO;
+
 public interface ValidationService {
+
+    String sendCode(MailType mailType, String scope, ValidationReqDTO.EmailCodeReqDTO emailCodeReqDTO);
 }

--- a/src/main/java/com/project/team5backend/global/validation/service/ValidationService.java
+++ b/src/main/java/com/project/team5backend/global/validation/service/ValidationService.java
@@ -6,4 +6,6 @@ import com.project.team5backend.global.validation.dto.request.ValidationReqDTO;
 public interface ValidationService {
 
     String sendCode(MailType mailType, String scope, ValidationReqDTO.EmailCodeReqDTO emailCodeReqDTO);
+
+    void verifyCode(ValidationReqDTO.EmailCodeValidationReqDTO emailCodeValidationReqDTO);
 }

--- a/src/main/java/com/project/team5backend/global/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/project/team5backend/global/validation/service/ValidationServiceImpl.java
@@ -1,0 +1,13 @@
+package com.project.team5backend.global.validation.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ValidationServiceImpl {
+}

--- a/src/main/java/com/project/team5backend/global/validation/service/ValidationServiceImpl.java
+++ b/src/main/java/com/project/team5backend/global/validation/service/ValidationServiceImpl.java
@@ -1,13 +1,70 @@
 package com.project.team5backend.global.validation.service;
 
+import com.project.team5backend.domain.user.repository.UserRepository;
+import com.project.team5backend.global.mail.MailType;
+import com.project.team5backend.global.mail.service.MailService;
+import com.project.team5backend.global.util.RedisUtils;
+import com.project.team5backend.global.validation.dto.request.ValidationReqDTO;
+import com.project.team5backend.global.validation.exception.ValidationErrorCode;
+import com.project.team5backend.global.validation.exception.ValidationException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import static com.project.team5backend.global.constant.redis.RedisConstant.*;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class ValidationServiceImpl {
+public class ValidationServiceImpl implements ValidationService {
+
+    private final UserRepository userRepository;
+    private final MailService mailService;
+    private final RedisUtils<String> redisUtils;
+
+    @Override
+    public String sendCode(MailType mailType, String scope, ValidationReqDTO.EmailCodeReqDTO emailCodeReqDTO) {
+        // 이메일을 가져온다
+        final String email = emailCodeReqDTO.email();
+        // 6자리 난수 코드
+        final String code = createVerificationCode();
+
+        boolean isEmailAlreadyExist = userRepository.findByEmail(email).isPresent();
+        boolean isEmailVerification = Objects.equals(mailType, MailType.SIGNUP_VERIFICATION);
+        // 회원 가입 이메일 인증인데, 이미 존재하는 이메일로 인증을 한 경우
+        if (isEmailAlreadyExist && isEmailVerification) {
+            throw new ValidationException(ValidationErrorCode.ALREADY_USED_EMAIL);
+        }
+
+        // 해당 이메일로 인증 번호를 보낸 적이 있다면 10초 대기
+        if (redisUtils.hasKey(email + KEY_COOLDOWN_SUFFIX)) {
+            throw new ValidationException(ValidationErrorCode.CODE_COOL_DOWN);
+        }
+
+        Map<String, String> mailContent = new HashMap<>();
+        mailContent.put("{{CODE}}", code);
+        mailContent.put("{{TTL_MINUTES}}", "5");
+        mailService.sendMail(mailType, email, mailContent);
+
+        // 성공 시
+        // 레디스에 인증 정보 저장
+        redisUtils.save(email + KEY_CODE_SUFFIX, code + ":" + scope, CODE_EXP_TIME, TimeUnit.MILLISECONDS);
+        // 쿨다운 키 저장 (연속 인증 방지)
+        redisUtils.save(email + KEY_COOLDOWN_SUFFIX, VALUE_COOLDOWN, COOLDOWN_EXP_TIME, TimeUnit.MILLISECONDS);
+        return code;
+    }
+
+    // 6자리 난수 생성기
+    private String createVerificationCode() {
+        SecureRandom random = new SecureRandom();
+        return String.format("%06d", random.nextInt(1000000));
+    }
 }


### PR DESCRIPTION
# ☝️Issue Number

- #121 

##  📌 개요

- 이메일 인증 템플릿 구현
- 이메일 발송 구현
- 이메일 인증 없이 회원가입 예외 처리
- 이메일이 기존에 가입된 회원가 겹치는 경우 예외 처리
- 이메일 인증 후 가입을 진행할 때, 다른 사람이 해당 이메일을 사용하지 못하게 처리
- 이메일 인증과 회원 가입을 연동

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점