### PR TITLE
🐛 fix: Spring Boot 3.5.3 환경에서 CORS 미적용 문제 수정

### DIFF
--- a/src/main/java/com/project/team5backend/global/config/CorsConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/CorsConfig.java
@@ -2,6 +2,7 @@ package com.project.team5backend.global.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -13,8 +14,9 @@ import java.util.Collections;
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
-    @Bean
-    public static CorsConfigurationSource apiConfigurationSource() {
+    @Bean("customCorsConfigurationSource")
+    @Primary
+    public CorsConfigurationSource apiConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
         // 허용할 Origin List
@@ -26,10 +28,11 @@ public class CorsConfig implements WebMvcConfigurer {
         allowedOrigins.add("https://artiee.store");
         allowedOrigins.add("https://api.artiee.store");
 
-        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedOriginPatterns(allowedOrigins);
 
         // 허용할 HTTP METHOD
         ArrayList<String> allowedHttpMethods = new ArrayList<>();
+        allowedHttpMethods.add("OPTIONS");
         allowedHttpMethods.add("GET");
         allowedHttpMethods.add("POST");
         allowedHttpMethods.add("PATCH");

--- a/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/project/team5backend/global/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import com.project.team5backend.global.security.repository.CustomCookieCsrfToken
 import com.project.team5backend.global.security.util.JwtUtil;
 import com.project.team5backend.global.util.RedisUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -24,6 +25,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration // 빈 등록
 @EnableWebSecurity // 필터 체인 관리 시작 어노테이션
@@ -39,6 +41,7 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomCookieCsrfTokenRepository customCookieCsrfTokenRepository;
+    private final @Qualifier("customCorsConfigurationSource") CorsConfigurationSource corsConfigurationSource;
 
 
     //인증이 필요하지 않은 url
@@ -63,7 +66,7 @@ public class SecurityConfig {
 
         http
                 // CORS CONFIG
-                .cors(cors -> cors.configurationSource(CorsConfig.apiConfigurationSource()))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
 
                 // 요쳥별 접근 권한 설정
                 .authorizeHttpRequests(request -> request


### PR DESCRIPTION
##  📌 개요

- 기존 도커 이미지가 자동으로 스프링 부트. 시큐리티 업데이트하면서 이전 방식에서 작동되던 static cors 구조가 작동되지 않았음

## 🔁 변경 사항
- static CORS Bean 제거 후 @Qualifier 기반 Bean 주입 방식으로 변경
- OPTIONS 메서드 추가 (Preflight 요청 대응)
- Bean 충돌(@CorsConfigurationSource) 문제 해결
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점